### PR TITLE
fix: update repo references to JARMourato/dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Interactive macOS setup CLI for provisioning machines from scratch. One command 
 
 ```bash
 # Run directly from GitHub (no clone needed)
-npx github:ultronservant/dotfiles#feat/npx-cli --profile work
+npx github:JARMourato/dotfiles --profile work
 
 # Or with a specific profile
-npx github:ultronservant/dotfiles#feat/npx-cli --profile minimal
+npx github:JARMourato/dotfiles --profile minimal
 ```
 
 ## Commands

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -382,7 +382,7 @@ async function stepPreviewAndSave(rootDir: string, state: EditorState): Promise<
     console.log(yaml);
     console.log(chalk.bold('── How to submit ──'));
     console.log('');
-    console.log(`1. Fork the repo:      ${chalk.cyan('gh repo fork ultronservant/dotfiles --clone')}`);
+    console.log(`1. Fork the repo:      ${chalk.cyan('gh repo fork JARMourato/dotfiles --clone')}`);
     console.log(`2. Save the profile:   ${chalk.cyan(`cat > profiles/${state.profileName}.yaml << 'EOF'\n${yaml}EOF`)}`);
     console.log(`3. Commit & push:      ${chalk.cyan(`git add profiles/${state.profileName}.yaml && git commit -m "Add ${state.profileName} profile" && git push`)}`);
     console.log(`4. Open a PR:          ${chalk.cyan('gh pr create --title "Add ' + state.profileName + ' profile"')}`);


### PR DESCRIPTION
Updates README quick start and editor PR instructions to point to JARMourato/dotfiles instead of the fork.