### PR TITLE
feat: add dotfiles alias for npx shortcut

### DIFF
--- a/dotfiles/.aliases
+++ b/dotfiles/.aliases
@@ -168,6 +168,9 @@ alias killgpg="pkill gpg-agent && gpg-agent --daemon"
 # Opens the Google Play Store console (beta view), ready to publish a new version of the app
 alias playstore="open -a safari https://play.google.com/console/u/1/developers/6280656057399977520/app-list"
 
+# CLI shortcut — run the dotfiles provisioner without the full npx command
+alias dotfiles="npx github:JARMourato/dotfiles"
+
 # Prints the PATH env var in a user-friendly way
 alias path="tr ':' '\n' <<< \"$PATH\""
 


### PR DESCRIPTION
Adds `alias dotfiles="npx github:JARMourato/dotfiles"` to `.aliases` so you can run `dotfiles --profile work` instead of the full npx command.