### PR TITLE
feat: repo clone + push/pull sync + ~/Workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ npx github:JARMourato/dotfiles --reset --dry-run
 # Run a single module
 npx github:JARMourato/dotfiles --module terminal
 
+# Pull latest dotfiles from repo
+dotfiles --pull
+
+# Push local dotfile changes to repo
+dotfiles --push
+
 # Show diff from previous run
 npx github:JARMourato/dotfiles --diff
 
@@ -93,12 +99,36 @@ Walk through an interactive wizard:
 
 ```
 ~/.dotfiles/
+  repo/           # Git clone of the dotfiles repo (push/pull support)
   files/          # Dotfile copies (symlinked from ~/)
   config/         # state.json, defaults-backup.json
   profiles/       # Custom profiles from --edit
 ```
 
 Everything stays in `~/.dotfiles/`. Home directory stays clean.
+
+## Sync
+
+On first install, the repo is cloned to `~/.dotfiles/repo/`. This gives you full git push/pull support:
+
+```bash
+# Edit a dotfile
+vim ~/.aliases
+
+# Push your changes back to the repo
+dotfiles --push
+
+# On another machine, pull the latest
+dotfiles --pull
+```
+
+The flow:
+1. **Install** clones the repo → `~/.dotfiles/repo/`
+2. Dotfiles are copied from repo → `~/.dotfiles/files/` and symlinked to `~/`
+3. **Push** copies edited files back to repo, commits, and pushes
+4. **Pull** fetches latest, copies to `~/.dotfiles/files/`, re-symlinks
+
+For push access, make sure your SSH key is added to GitHub.
 
 ## Reset
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ program
   .option('--status', 'show machine status vs dotfiles managed items')
   .option('--reset', 'aggressively undo dotfiles changes')
   .option('--edit', 'create or edit a profile interactively')
+  .option('--pull', 'pull latest dotfiles from repo')
+  .option('--push', 'push local dotfile changes to repo')
   .parse(process.argv);
 
 const options = program.opts<{
@@ -53,6 +55,8 @@ const options = program.opts<{
   status?: boolean;
   reset?: boolean;
   edit?: boolean;
+  pull?: boolean;
+  push?: boolean;
 }>();
 
 function handleCancelled<T>(value: T): T {
@@ -359,6 +363,18 @@ async function run(): Promise<void> {
 
   if (options.status) {
     await showStatus(rootDir);
+    return;
+  }
+
+  if (options.pull) {
+    const { pullRepo } = await import('./sync');
+    await pullRepo();
+    return;
+  }
+
+  if (options.push) {
+    const { pushRepo } = await import('./sync');
+    await pushRepo();
     return;
   }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -21,3 +21,9 @@ export const BACKUP_PATH = path.join(CONFIG_DIR, 'defaults-backup.json');
 
 /** Root ~/.dotfiles directory */
 export const DOTFILES_ROOT = DOTFILES_HOME;
+
+/** Git clone of the dotfiles repo */
+export const REPO_DIR = path.join(DOTFILES_HOME, 'repo');
+
+/** ~/Workspace directory */
+export const WORKSPACE_DIR = path.join(realHome(), 'Workspace');

--- a/src/required.ts
+++ b/src/required.ts
@@ -108,7 +108,16 @@ async function ensureGitConfig(opts: InstallOptions): Promise<void> {
 }
 
 async function ensureDotfiles(opts: InstallOptions): Promise<void> {
-  const srcDir = path.join(opts.rootDir, 'dotfiles');
+  const { REPO_DIR } = await import('./paths');
+  const repoSrc = path.join(REPO_DIR, 'dotfiles');
+  // Prefer repo clone dotfiles if available, else use bundled
+  let srcDir: string;
+  try {
+    await fs.access(repoSrc);
+    srcDir = repoSrc;
+  } catch {
+    srcDir = path.join(opts.rootDir, 'dotfiles');
+  }
   const home = realHome();
   const { DOTFILES_DIR: dotfilesDir } = await import('./paths');
   const sudoUser = process.env.SUDO_USER;
@@ -200,6 +209,15 @@ async function ensureHostname(opts: InstallOptions): Promise<void> {
   await runCommand('scutil', ['--set', 'HostName', name], { continueOnError: true });
 }
 
+async function ensureWorkspace(opts: InstallOptions): Promise<void> {
+  const { WORKSPACE_DIR } = await import('./paths');
+  if (opts.dryRun) {
+    log.info(`[dry-run] mkdir -p ${WORKSPACE_DIR}`);
+    return;
+  }
+  await fs.mkdir(WORKSPACE_DIR, { recursive: true });
+}
+
 async function acquireSudo(dryRun: boolean): Promise<void> {
   if (dryRun) return;
   // Request sudo upfront and validate — some modules need it (openjdk symlink, pmset, app removal)
@@ -221,7 +239,11 @@ export async function runRequiredPhase(opts: InstallOptions): Promise<void> {
     await ensureSshKey(opts);
     await ensureGitConfig(opts);
     await ensureDotfiles(opts);
+    await ensureWorkspace(opts);
     s.stop('Required phase complete');
+    // Clone repo for sync support (after spinner, may need network)
+    const { cloneRepo } = await import('./sync');
+    await cloneRepo(opts.dryRun);
     // Hostname prompt needs visible terminal — run after spinner
     await ensureHostname(opts);
   } catch (error) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,0 +1,179 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { log, spinner } from '@clack/prompts';
+import chalk from 'chalk';
+import { REPO_DIR, DOTFILES_DIR } from './paths';
+import { runCommand, realHome } from './utils/shell';
+
+const REPO_URL = 'https://github.com/JARMourato/dotfiles.git';
+const SSH_URL = 'git@github.com:JARMourato/dotfiles.git';
+
+/** Check if the repo clone exists */
+export async function hasRepoClone(): Promise<boolean> {
+  try {
+    await fs.access(path.join(REPO_DIR, '.git'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Clone the dotfiles repo to ~/.dotfiles/repo/ */
+export async function cloneRepo(dryRun = false): Promise<void> {
+  if (await hasRepoClone()) return;
+
+  if (dryRun) {
+    log.info(`[dry-run] git clone ${REPO_URL} ${REPO_DIR}`);
+    return;
+  }
+
+  const s = spinner();
+  s.start('Cloning dotfiles repo...');
+
+  // Try SSH first (for push access), fall back to HTTPS
+  let result = await runCommand('git', ['clone', SSH_URL, REPO_DIR], { continueOnError: true });
+  if (!result.ok) {
+    result = await runCommand('git', ['clone', REPO_URL, REPO_DIR], { continueOnError: true });
+  }
+
+  if (result.ok) {
+    s.stop('Dotfiles repo cloned to ~/.dotfiles/repo/');
+  } else {
+    s.stop('Could not clone dotfiles repo (continuing without sync support)');
+  }
+}
+
+/** Get the dotfiles source dir — prefer repo clone, fall back to bundled */
+export function getDotfilesSource(rootDir: string): string {
+  // We check synchronously via the caller; this just returns the path
+  return path.join(REPO_DIR, 'dotfiles');
+}
+
+/** Pull latest changes from origin */
+export async function pullRepo(): Promise<void> {
+  if (!(await hasRepoClone())) {
+    log.error('No repo clone found. Run an install first to set up the repo.');
+    return;
+  }
+
+  const s = spinner();
+  s.start('Pulling latest changes...');
+
+  // Stash any local changes
+  await runCommand('git', ['-C', REPO_DIR, 'stash'], { continueOnError: true });
+
+  const result = await runCommand('git', ['-C', REPO_DIR, 'pull', '--rebase'], { continueOnError: true });
+
+  // Pop stash
+  await runCommand('git', ['-C', REPO_DIR, 'stash', 'pop'], { continueOnError: true });
+
+  if (result.ok) {
+    s.stop('Up to date.');
+
+    // Re-copy dotfiles from repo to ~/.dotfiles/files/ and re-symlink
+    await syncDotfilesToHome();
+  } else {
+    s.stop(chalk.yellow('Pull failed. You may need to resolve conflicts manually.'));
+    log.info(`  cd ~/.dotfiles/repo && git status`);
+  }
+}
+
+/** Push local dotfile changes back to repo */
+export async function pushRepo(): Promise<void> {
+  if (!(await hasRepoClone())) {
+    log.error('No repo clone found. Run an install first to set up the repo.');
+    return;
+  }
+
+  // Check for SSH remote (needed for push)
+  const remote = await runCommand('git', ['-C', REPO_DIR, 'remote', 'get-url', 'origin'], { continueOnError: true });
+  if (remote.ok && remote.stdout.trim().startsWith('https://')) {
+    // Switch to SSH for push
+    log.info('Switching remote to SSH for push access...');
+    await runCommand('git', ['-C', REPO_DIR, 'remote', 'set-url', 'origin', SSH_URL], { continueOnError: true });
+  }
+
+  // Copy managed dotfiles from ~/.dotfiles/files/ back to repo
+  const s = spinner();
+  s.start('Syncing dotfiles to repo...');
+
+  const dotfilesInRepo = path.join(REPO_DIR, 'dotfiles');
+  const managedFiles = ['.aliases', '.exports', '.paths', '.gemrc', '.ruby-version', '.zshrc'];
+
+  for (const file of managedFiles) {
+    const src = path.join(DOTFILES_DIR, file);
+    const dst = path.join(dotfilesInRepo, file);
+    try {
+      await fs.access(src);
+      await fs.copyFile(src, dst);
+    } catch { /* file doesn't exist in managed dir */ }
+  }
+
+  s.stop('Dotfiles synced to repo.');
+
+  // Check if there are changes
+  const status = await runCommand('git', ['-C', REPO_DIR, 'status', '--porcelain'], { continueOnError: true });
+  if (!status.stdout.trim()) {
+    log.info('Nothing to push — repo is up to date.');
+    return;
+  }
+
+  // Show what changed
+  log.info(chalk.bold('Changes to push:'));
+  const diff = await runCommand('git', ['-C', REPO_DIR, 'diff', '--stat'], { continueOnError: true });
+  if (diff.stdout.trim()) console.log(diff.stdout);
+
+  const untracked = await runCommand('git', ['-C', REPO_DIR, 'status', '--porcelain'], { continueOnError: true });
+  if (untracked.stdout.trim()) console.log(chalk.dim(untracked.stdout));
+
+  // Stage, commit, push
+  await runCommand('git', ['-C', REPO_DIR, 'add', '-A'], { continueOnError: true });
+  const commitResult = await runCommand('git', ['-C', REPO_DIR, 'commit', '-m', 'Update dotfiles'], { continueOnError: true });
+
+  if (!commitResult.ok) {
+    log.error('Commit failed.');
+    return;
+  }
+
+  const pushResult = await runCommand('git', ['-C', REPO_DIR, 'push'], { continueOnError: true });
+
+  if (pushResult.ok) {
+    log.success('Pushed to origin.');
+  } else {
+    log.error('Push failed. Check your SSH key and repo permissions.');
+    log.info(`  cd ~/.dotfiles/repo && git push`);
+  }
+}
+
+/** Copy dotfiles from repo clone to ~/.dotfiles/files/ and re-symlink to ~/ */
+async function syncDotfilesToHome(): Promise<void> {
+  const repoSource = path.join(REPO_DIR, 'dotfiles');
+  const home = realHome();
+  const managedFiles = ['.aliases', '.exports', '.paths', '.gemrc', '.ruby-version', '.zshrc'];
+
+  await fs.mkdir(DOTFILES_DIR, { recursive: true });
+
+  for (const file of managedFiles) {
+    const src = path.join(repoSource, file);
+    const managed = path.join(DOTFILES_DIR, file);
+    const homeLink = path.join(home, file);
+
+    try {
+      await fs.access(src);
+    } catch {
+      continue; // file doesn't exist in repo
+    }
+
+    // Copy to managed dir
+    await fs.copyFile(src, managed);
+
+    // Ensure symlink
+    try {
+      const existing = await fs.readlink(homeLink);
+      if (existing === managed) continue;
+    } catch { /* not a symlink */ }
+
+    await fs.rm(homeLink, { force: true });
+    await fs.symlink(managed, homeLink);
+  }
+}


### PR DESCRIPTION
## What

Restores the git push/pull workflow that existed before the npx migration, plus creates `~/Workspace`.

## Changes

### Repo clone on first install
- Clones `JARMourato/dotfiles` to `~/.dotfiles/repo/` during the required phase
- Tries SSH first (for push access), falls back to HTTPS
- When the clone exists, dotfiles are sourced from it instead of the npx bundle

### Push & Pull commands
- `dotfiles --pull` — pulls latest from origin, re-copies dotfiles to `~/.dotfiles/files/`, re-symlinks to `~/`
- `dotfiles --push` — copies edited dotfiles from `~/.dotfiles/files/` back to the repo, commits, and pushes
- Auto-switches remote to SSH if needed for push

### ~/Workspace
- Creates `~/Workspace` directory during required setup phase

### Flow
```
Install → clones repo to ~/.dotfiles/repo/
        → copies dotfiles to ~/.dotfiles/files/
        → symlinks to ~/

Edit    → vim ~/.aliases (edits the symlinked file in ~/.dotfiles/files/)

Push    → copies ~/.dotfiles/files/ → ~/.dotfiles/repo/dotfiles/
        → git add + commit + push

Pull    → git pull in ~/.dotfiles/repo/
        → copies repo/dotfiles/ → ~/.dotfiles/files/
        → re-symlinks to ~/
```