### PR TITLE
fix: screenshot dir ownership + git clone cleanup

### DIFF
--- a/src/modules/macos.ts
+++ b/src/modules/macos.ts
@@ -325,6 +325,11 @@ export const macosModule: ModuleV2 = {
       if (screen.screenshot_location) {
         const location = asString(screen.screenshot_location).replace(/^~\//, `${realHome()}/`);
         await runCommand('mkdir', ['-p', location], { dryRun: opts.dryRun, continueOnError: true });
+        // Ensure the directory is owned by the real user (not root when running under sudo)
+        const user = process.env.SUDO_USER || process.env.USER;
+        if (user) {
+          await runCommand('chown', [user, location], { dryRun: opts.dryRun, continueOnError: true });
+        }
         await defaultsWrite('com.apple.screencapture', 'location', location, opts.dryRun);
       }
       if (screen.screenshot_format) await defaultsWrite('com.apple.screencapture', 'type', screen.screenshot_format, opts.dryRun);

--- a/src/modules/terminal.ts
+++ b/src/modules/terminal.ts
@@ -73,7 +73,7 @@ export const terminalModule: ModuleV2 = {
     if (item === 'fonts') {
       await runCommand(
         'bash',
-        ['-lc', 'if ! ls ~/Library/Fonts/Meslo* >/dev/null 2>&1; then git clone https://github.com/powerline/fonts.git --depth=1 && cd fonts && ./install.sh "Meslo LG" && cd .. && rm -rf fonts; fi'],
+        ['-lc', 'if ! ls ~/Library/Fonts/Meslo* >/dev/null 2>&1; then cd /tmp && git clone https://github.com/powerline/fonts.git --depth=1 && cd fonts && ./install.sh "Meslo LG" && cd /tmp && rm -rf fonts; fi'],
         { dryRun: opts.dryRun, continueOnError: true },
       );
     }
@@ -81,7 +81,7 @@ export const terminalModule: ModuleV2 = {
     if (item === 'powerline') {
       await runCommand(
         'bash',
-        ['-lc', 'if ! command -v powerline-shell >/dev/null 2>&1; then git clone https://github.com/b-ryan/powerline-shell.git --depth=1 && cd powerline-shell && python3 setup.py install && cd .. && rm -rf powerline-shell; fi'],
+        ['-lc', 'if ! command -v powerline-shell >/dev/null 2>&1; then cd /tmp && git clone https://github.com/b-ryan/powerline-shell.git --depth=1 && cd powerline-shell && python3 setup.py install && cd /tmp && rm -rf powerline-shell; fi'],
         { dryRun: opts.dryRun, continueOnError: true },
       );
 


### PR DESCRIPTION
Two fixes:

1. **Screenshot directory ownership**: `mkdir -p ~/Pictures/Screenshots` under sudo creates the dir as root, so the Screenshot app can't write to it. Now `chown`s to the real user after creation.

2. **Git clone location**: powerline-shell and fonts were cloned into cwd (defaulting to ~/), leaving leftover dirs if install failed. Now clones to /tmp.