### PR TITLE
feat: add gh CLI to core tools

### DIFF
--- a/profiles/work.yaml
+++ b/profiles/work.yaml
@@ -1,7 +1,7 @@
 name: work
 description: "Work machine — iOS, Android, Rails (Docker), web dev, AI tools"
 
-core: [jq, curl, wget, tree, bat, fd, ripgrep, htop]
+core: [jq, curl, wget, tree, bat, fd, ripgrep, htop, gh]
 terminal: [oh-my-zsh, powerline, theme, fonts]
 languages: [python, ruby]
 ios: [xcode, swiftlint, swiftformat, xcbeautify, asc]

--- a/src/modules/core.ts
+++ b/src/modules/core.ts
@@ -10,12 +10,13 @@ const items = [
   { id: 'fd', label: 'fd' },
   { id: 'ripgrep', label: 'ripgrep' },
   { id: 'htop', label: 'htop' },
+  { id: 'gh', label: 'GitHub CLI' },
 ];
 
 export const coreModule: ModuleV2 = {
   name: 'core',
   label: 'Core Tools',
-  description: 'jq, curl, wget, tree, bat, fd, ripgrep, htop',
+  description: 'jq, curl, wget, tree, bat, fd, ripgrep, htop, gh',
   items,
   defaultItems: items.map((item) => item.id),
   async detect(selectedItems) {


### PR DESCRIPTION
Adds `gh` (GitHub CLI) to the core module and work profile. Needed for SSH key upload and general GitHub operations.