### PR TITLE
feat(ai): switch claude-code from npm to native installer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -438,10 +438,12 @@ async function run(): Promise<void> {
         log.info(`  🗑  ${mod.label}: ${parts.join(' + ')}`);
       } else if (mod.name === 'ai') {
         const casks = mod.items.filter((i) => i === 'claude' || i === 'chatgpt');
-        const npms = mod.items.filter((i) => i === 'claude-code' || i === 'codex');
+        const natives = mod.items.filter((i) => i === 'claude-code');
+        const npms = mod.items.filter((i) => i === 'codex');
         const parts: string[] = [];
         if (casks.length > 0) parts.push(`brew uninstall --cask ${casks.join(', ')}`);
-        if (npms.length > 0) parts.push(`npm uninstall -g ${npms.map((p) => p === 'claude-code' ? '@anthropic-ai/claude-code' : p === 'codex' ? '@openai/codex' : p).join(', ')}`);
+        if (natives.length > 0) parts.push(`claude uninstall`);
+        if (npms.length > 0) parts.push(`npm uninstall -g ${npms.map((p) => p === 'codex' ? '@openai/codex' : p).join(', ')}`);
         log.info(`  🗑  ${mod.label}: ${parts.join(' + ')}`);
       } else {
         log.info(`  🗑  ${mod.label}: ${mod.items.join(', ')}`);
@@ -485,10 +487,15 @@ async function run(): Promise<void> {
         if (formulas.length > 0) await uninstallFormulas(formulas, uninstallOpts);
       } else if (mod.name === 'ai') {
         const casks = mod.items.filter((i) => i === 'claude' || i === 'chatgpt');
-        const npms = mod.items.filter((i) => i === 'claude-code' || i === 'codex');
+        const natives = mod.items.filter((i) => i === 'claude-code');
+        const npms = mod.items.filter((i) => i === 'codex');
         if (casks.length > 0) await uninstallCasks(casks, uninstallOpts);
+        for (const item of natives) {
+          const bin = item === 'claude-code' ? 'claude' : item;
+          await runCommand(bin, ['uninstall'], { continueOnError: true });
+        }
         for (const pkg of npms) {
-          const npmName = pkg === 'claude-code' ? '@anthropic-ai/claude-code' : pkg === 'codex' ? '@openai/codex' : pkg;
+          const npmName = pkg === 'codex' ? '@openai/codex' : pkg;
           await runCommand('npm', ['uninstall', '-g', npmName], { continueOnError: true });
         }
       }

--- a/src/modules/ai.ts
+++ b/src/modules/ai.ts
@@ -11,8 +11,11 @@ const items = [
 
 const CASK_IDS = new Set(['claude', 'chatgpt']);
 const NPM_PACKAGES: Record<string, string> = {
-  'claude-code': '@anthropic-ai/claude-code',
   'codex': '@openai/codex',
+};
+// claude-code uses its native installer (auto-updates)
+const NATIVE_INSTALLERS: Record<string, { install: string[]; bin: string }> = {
+  'claude-code': { install: ['bash', '-c', 'curl -fsSL https://claude.ai/install.sh | bash'], bin: 'claude' },
 };
 
 export const aiModule: ModuleV2 = {
@@ -24,7 +27,7 @@ export const aiModule: ModuleV2 = {
   dependencies: ['core'],
   async detect(selectedItems) {
     const casks = selectedItems.filter((item) => CASK_IDS.has(item));
-    const cliItems = selectedItems.filter((item) => item in NPM_PACKAGES);
+    const cliItems = selectedItems.filter((item) => item in NPM_PACKAGES || item in NATIVE_INSTALLERS);
 
     const caskDetect = casks.length > 0
       ? await detectCasks(casks)
@@ -33,7 +36,7 @@ export const aiModule: ModuleV2 = {
     const commandInstalled: string[] = [];
     const commandMissing: string[] = [];
     for (const item of cliItems) {
-      const bin = item === 'claude-code' ? 'claude' : 'codex';
+      const bin = NATIVE_INSTALLERS[item]?.bin ?? item;
       const check = await runAsUser('which', [bin], { continueOnError: true });
       if (check.ok) commandInstalled.push(item);
       else commandMissing.push(item);
@@ -54,6 +57,20 @@ export const aiModule: ModuleV2 = {
   async installItem(item, opts) {
     if (CASK_IDS.has(item)) {
       await installCask(item, opts);
+      return;
+    }
+
+    const native = NATIVE_INSTALLERS[item];
+    if (native) {
+      const result = await runAsUser(native.install[0], native.install.slice(1), {
+        dryRun: opts.dryRun,
+        continueOnError: true,
+        timeoutMs: 180_000,
+      });
+      if (!result.ok) {
+        const err = (result.stderr || result.stdout).trim().slice(0, 300);
+        throw new Error(`Native install of ${item} failed: ${err || 'timed out after 3 minutes'}`);
+      }
       return;
     }
 

--- a/src/reset.ts
+++ b/src/reset.ts
@@ -80,7 +80,10 @@ const MANAGED_MAS_APPS = [
   { id: 904280696, name: 'Things 3' },
   { id: 441258766, name: 'Magnet' },
 ];
-const NPM_GLOBALS = ['@anthropic-ai/claude-code', '@openai/codex'];
+const NPM_GLOBALS = ['@openai/codex'];
+const NATIVE_UNINSTALLERS: { id: string; bin: string; args: string[] }[] = [
+  { id: 'claude-code', bin: 'claude', args: ['uninstall'] },
+];
 const DOTFILES = ['.aliases', '.exports', '.paths', '.gemrc', '.ruby-version', '.zshrc'];
 const ANDROID_ENV_MARKER = '# macsetup: android env';
 
@@ -227,7 +230,7 @@ export async function runReset(rootDir: string, dryRun: boolean): Promise<void> 
   log.info(`2) Uninstall formulas: ${MANAGED_FORMULAS.join(', ')}`);
   log.info(`3) Uninstall casks: ${MANAGED_CASKS.join(', ')}`);
   log.info(`4) Uninstall Mac App Store apps: ${MANAGED_MAS_APPS.map((a) => a.name).join(', ')}`);
-  log.info(`5) Uninstall npm globals: ${NPM_GLOBALS.join(', ')}`);
+  log.info(`5) Uninstall CLI tools: ${NATIVE_UNINSTALLERS.map((n) => n.id).join(', ')}, ${NPM_GLOBALS.join(', ')}`);
   log.info(`6) Remove dotfile symlinks + ~/.dotfiles/ directory: ${DOTFILES.join(', ')}`);
   log.info('7) Remove ~/.oh-my-zsh and ~/.config/powerline-shell');
   log.info('8) Uninstall powerline-shell (pip3)');
@@ -293,8 +296,14 @@ export async function runReset(rootDir: string, dryRun: boolean): Promise<void> 
   progress('Uninstalling Mac App Store apps');
   await uninstallMasApps(false);
 
-  // 5) Uninstall npm globals
-  progress('Uninstalling npm globals');
+  // 5) Uninstall CLI tools (native + npm)
+  progress('Uninstalling CLI tools');
+  for (const native of NATIVE_UNINSTALLERS) {
+    log.info(chalk.dim(`  → ${native.id} (native uninstaller)`));
+    if (await commandExists(native.bin)) {
+      await runAsUser(native.bin, native.args, { continueOnError: true });
+    }
+  }
   for (const pkg of NPM_GLOBALS) {
     log.info(chalk.dim(`  → ${pkg}`));
     // Try as user first (normal case), then with sudo if it fails (e.g. global prefix owned by root)

--- a/src/status.ts
+++ b/src/status.ts
@@ -64,8 +64,9 @@ const MANAGED_CASKS = new Set([
   'claude',
   'chatgpt',
 ]);
-const NPM_GLOBALS = [
-  { label: 'claude-code', packageName: '@anthropic-ai/claude-code' },
+const NPM_GLOBALS: { label: string; packageName: string }[] = [];
+const NATIVE_CLI_TOOLS = [
+  { label: 'claude-code', bin: 'claude' },
 ];
 const MACOS_BASELINE: Record<string, BaselineCheck[]> = {
   dock: [
@@ -148,7 +149,12 @@ export async function showStatus(rootDir: string): Promise<void> {
     if (casks.length === 0) line('☐', 'No casks installed');
   }
 
-  log.info(chalk.bold(chalk.cyan('Status: npm Globals')));
+  log.info(chalk.bold(chalk.cyan('Status: CLI Tools')));
+  for (const tool of NATIVE_CLI_TOOLS) {
+    const check = await runCommand('which', [tool.bin], { continueOnError: true });
+    if (check.ok) line(chalk.green('✅'), tool.label, '(installed)');
+    else line('☐', tool.label, '(not installed)');
+  }
   for (const pkg of NPM_GLOBALS) {
     if (await npmGlobalInstalled(pkg.packageName)) line(chalk.green('✅'), pkg.label, '(installed)');
     else line('☐', pkg.label, '(not installed)');


### PR DESCRIPTION
Claude Code has moved from npm to a native installer that auto-updates.

## Changes

- **ai.ts**: Install via `curl -fsSL https://claude.ai/install.sh | bash` instead of `npm install -g @anthropic-ai/claude-code`
- **reset.ts**: Uninstall via `claude uninstall` instead of `npm uninstall -g`
- **status.ts**: Detect via `which claude` binary check instead of `npm ls -g`
- **index.ts**: Update uninstall preview and execution paths

Ref: https://docs.anthropic.com/en/docs/claude-code/overview