### PR TITLE
docs: add bootstrap one-liner as primary quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,17 @@ Interactive macOS setup CLI for provisioning machines from scratch. One command 
 
 ## Quick Start
 
+On a **fresh Mac** (nothing installed yet):
+
 ```bash
-# Run directly from GitHub (no clone needed)
+bash <(curl -Lks https://raw.githubusercontent.com/JARMourato/dotfiles/main/bootstrap.sh)
+```
+
+This installs Xcode CLI tools, Homebrew, and Node.js automatically, then runs the interactive setup.
+
+Once Node.js is available, you can also run directly:
+
+```bash
 npx github:JARMourato/dotfiles --profile work
 ```
 


### PR DESCRIPTION
The README Quick Start showed `npx github:JARMourato/dotfiles` which requires Node.js — not available on a fresh Mac.

Now the bootstrap curl command comes first:

```bash
bash <(curl -Lks https://raw.githubusercontent.com/JARMourato/dotfiles/main/bootstrap.sh)
```

The `npx` command is still there as an alternative for machines that already have Node.