### PR TITLE
fix: run xcodes install interactively for 2FA support

### DIFF
--- a/src/modules/ios.ts
+++ b/src/modules/ios.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { isCancel, password, text } from '@clack/prompts';
 import type { ModuleV2 } from '../types';
 import { detectFormulas, installFormula, installFormulas } from './helpers';
-import { brewFormulaInstalled, commandExists, realHome, runCommand, runStreamedCommand } from '../utils/shell';
+import { brewFormulaInstalled, commandExists, realHome, runCommand, runInteractive, runStreamedCommand } from '../utils/shell';
 
 const items = [
   { id: 'xcode', label: 'Xcode (via xcodes)', description: 'Full Xcode installation', critical: true },
@@ -124,13 +124,12 @@ export const iosModule: ModuleV2 = {
     if (selectedItems.includes('xcode')) {
       await ensureXcodes(opts);
       if (!opts.dryRun) await ensureXcodesAuth();
-      const result = await runCommand('xcodes', ['install', '--latest', '--experimental-unxip'], {
+      // Run interactively so the user can respond to 2FA prompts
+      const result = await runInteractive('xcodes', ['install', '--latest', '--experimental-unxip'], {
         dryRun: opts.dryRun,
-        continueOnError: true,
       });
       if (!result.ok) {
-        const output = (result.stderr || result.stdout).trim();
-        console.error(`  ⚠ xcodes install failed: ${output || 'unknown error'}`);
+        console.error('  ⚠ xcodes install failed');
       }
       await copyXcodeTemplateMacros(opts);
     }
@@ -142,17 +141,14 @@ export const iosModule: ModuleV2 = {
   },
   async installItem(item, opts) {
     if (item === 'xcode') {
-      const run = opts.onProgress ? runStreamedCommand : runCommand;
       await ensureXcodes(opts);
       if (!opts.dryRun) await ensureXcodesAuth();
-      const result = await run('xcodes', ['install', '--latest', '--experimental-unxip'], {
+      // Run interactively so the user can respond to 2FA prompts
+      const result = await runInteractive('xcodes', ['install', '--latest', '--experimental-unxip'], {
         dryRun: opts.dryRun,
-        continueOnError: true,
-        onProgress: opts.onProgress,
       });
       if (!result.ok) {
-        const output = (result.stderr || result.stdout).trim();
-        console.error(`  ⚠ xcodes install failed: ${output || 'unknown error'}`);
+        console.error('  ⚠ xcodes install failed');
       }
       await copyXcodeTemplateMacros(opts);
     } else {

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -144,6 +144,26 @@ export async function runCommand(
   }
 }
 
+/** Run a command with full stdio inheritance — for interactive prompts (e.g. 2FA) */
+export async function runInteractive(
+  cmd: string,
+  args: string[] = [],
+  opts: { dryRun?: boolean; env?: Record<string, string> } = {},
+): Promise<{ ok: boolean }> {
+  if (opts.dryRun) {
+    console.log(`[dry-run] ${cmd} ${args.join(' ')}`);
+    return { ok: true };
+  }
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      env: { ...process.env, ...opts.env },
+    });
+    child.on('close', (code) => resolve({ ok: code === 0 }));
+    child.on('error', () => resolve({ ok: false }));
+  });
+}
+
 export async function runCapture(cmd: string, args: string[] = [], cwd?: string): Promise<string> {
   const result = await execa(cmd, args, { cwd, shell: false });
   return result.stdout;


### PR DESCRIPTION
`xcodes install` needs the user to enter a 6-digit 2FA code from their trusted device. Previously it ran with captured stdio (execa), so the 2FA prompt was never visible and the code couldn't be typed in.

**Fix:** Added `runInteractive()` helper that uses `stdio: 'inherit'` — gives `xcodes` the real terminal so the user can enter the 2FA code directly.