### PR TITLE
fix: refresh sudo before each module to prevent pkg installer hangs

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,4 +1,5 @@
 import { log, spinner } from '@clack/prompts';
+import { runCommand } from './utils/shell';
 import type { InstallOptions, ModuleV2, StateFile } from './types';
 
 function resolveExecutionOrder(modules: ModuleV2[], selected: string[]): ModuleV2[] {
@@ -48,6 +49,11 @@ export async function runModules(
   for (const module of order) {
     const selectedItems = selected[module.name] ?? [];
     if (selectedItems.length === 0) continue;
+
+    // Refresh sudo timestamp before each module so pkg installers don't hang
+    if (!opts.dryRun) {
+      await runCommand('sudo', ['-v'], { continueOnError: true });
+    }
 
     const s = spinner();
     let spinnerActive = false;


### PR DESCRIPTION
Sudo is acquired once at the start of the required phase, but the 5-minute timeout can expire by the time later modules run. Cask installs like Zoom run `.pkg` files with `sudo`, and if the timestamp expired, the password prompt gets swallowed by the spinner — causing the install to hang silently.

Fix: `sudo -v` before each module to refresh the timestamp.