### PR TITLE
fix: sudo refresh — only prompt when expired, use real terminal

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,5 +1,5 @@
+import { execFileSync } from 'node:child_process';
 import { log, spinner } from '@clack/prompts';
-import { runCommand } from './utils/shell';
 import type { InstallOptions, ModuleV2, StateFile } from './types';
 
 function resolveExecutionOrder(modules: ModuleV2[], selected: string[]): ModuleV2[] {
@@ -50,9 +50,18 @@ export async function runModules(
     const selectedItems = selected[module.name] ?? [];
     if (selectedItems.length === 0) continue;
 
-    // Refresh sudo timestamp before each module so pkg installers don't hang
+    // Refresh sudo timestamp before each module so pkg installers don't hang.
+    // Use -n (non-interactive) first to check if sudo is still valid — only
+    // prompt with stdio:'inherit' if it actually expired.
     if (!opts.dryRun) {
-      await runCommand('sudo', ['-v'], { continueOnError: true });
+      try {
+        execFileSync('sudo', ['-n', 'true'], { stdio: 'ignore' });
+      } catch {
+        // Sudo expired — prompt with real terminal access
+        try {
+          execFileSync('sudo', ['-v'], { stdio: 'inherit' });
+        } catch { /* continue without sudo */ }
+      }
     }
 
     const s = spinner();


### PR DESCRIPTION
PR #23 used `runCommand('sudo', ['-v'])` which captured stdio — the password prompt was invisible and it asked before **every** module even when sudo was still valid.

**Fix:**
1. `sudo -n true` (non-interactive, silent) — checks if sudo is still valid
2. Only if expired → `execFileSync('sudo', ['-v'], { stdio: 'inherit' })` — real terminal for password input
3. No more password prompts on every module