### PR TITLE
fix: acquire sudo with real terminal + keep alive for entire install

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { Command } from 'commander';
 import { loadProfile, loadUserConfig, saveUserConfig } from './config';
 import { modules } from './modules';
 import { masAppsForItems, masItemsFromApps } from './modules/mas';
-import { runRequiredPhase } from './required';
+import { runRequiredPhase, stopSudoKeepAlive } from './required';
 import { runReset } from './reset';
 import { runModules } from './runner';
 import { showStatus } from './status';
@@ -604,6 +604,7 @@ async function run(): Promise<void> {
   await runRequiredPhase(installOpts);
 
   const result = await runModules(modules, selected, installOpts);
+  stopSudoKeepAlive();
   result.state.machine = machine;
 
   await state.save(result.state);

--- a/src/required.ts
+++ b/src/required.ts
@@ -309,12 +309,27 @@ async function ensureWorkspace(opts: InstallOptions): Promise<void> {
   await fs.mkdir(WORKSPACE_DIR, { recursive: true });
 }
 
+let sudoKeepAliveTimer: ReturnType<typeof setInterval> | null = null;
+
 async function acquireSudo(dryRun: boolean): Promise<void> {
   if (dryRun) return;
-  // Request sudo upfront and validate — some modules need it (openjdk symlink, pmset, app removal)
-  const check = await runCommand('sudo', ['-v'], { continueOnError: true });
-  if (!check.ok) {
+  // Request sudo upfront with real terminal access for the password prompt
+  try {
+    execSync('sudo -v', { stdio: 'inherit' });
+  } catch {
     log.warn('Could not acquire sudo. Some operations may be skipped.');
+    return;
+  }
+  // Keep sudo alive for the entire install by refreshing every 60s
+  sudoKeepAliveTimer = setInterval(() => {
+    try { execSync('sudo -n true', { stdio: 'ignore' }); } catch { /* expired, will re-prompt if needed */ }
+  }, 60_000);
+}
+
+export function stopSudoKeepAlive(): void {
+  if (sudoKeepAliveTimer) {
+    clearInterval(sudoKeepAliveTimer);
+    sudoKeepAliveTimer = null;
   }
 }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process';
 import { log, spinner } from '@clack/prompts';
 import type { InstallOptions, ModuleV2, StateFile } from './types';
 
@@ -49,20 +48,6 @@ export async function runModules(
   for (const module of order) {
     const selectedItems = selected[module.name] ?? [];
     if (selectedItems.length === 0) continue;
-
-    // Refresh sudo timestamp before each module so pkg installers don't hang.
-    // Use -n (non-interactive) first to check if sudo is still valid — only
-    // prompt with stdio:'inherit' if it actually expired.
-    if (!opts.dryRun) {
-      try {
-        execFileSync('sudo', ['-n', 'true'], { stdio: 'ignore' });
-      } catch {
-        // Sudo expired — prompt with real terminal access
-        try {
-          execFileSync('sudo', ['-v'], { stdio: 'inherit' });
-        } catch { /* continue without sudo */ }
-      }
-    }
 
     const s = spinner();
     let spinnerActive = false;


### PR DESCRIPTION
**Root cause:** `acquireSudo` used `runCommand('sudo', ['-v'])` which captures stdio. The password prompt was **never visible**, so sudo was never actually acquired. Every subsequent sudo call would re-prompt (also captured/invisible), causing the repeated password requests.

**Fix:**
- `acquireSudo` now uses `execSync('sudo -v', { stdio: 'inherit' })` — user sees the prompt and types the password once
- Background `setInterval` refreshes sudo every 60s so it never expires during the install
- Removed per-module sudo refresh from runner (no longer needed)

One password prompt at the start, zero after that.