### PR TITLE
fix: add ~/.local/bin to PATH for Claude Code CLI

### DIFF
--- a/dotfiles/.paths
+++ b/dotfiles/.paths
@@ -1,5 +1,8 @@
 # Optimized for Apple Silicon Macs only
 
+# Local binaries (Claude Code, etc.)
+export PATH="$HOME/.local/bin:$PATH"
+
 export PATH="$HOME/.rbenv/shims:$PATH"
 export PATH="$HOME/.rbenv/bin:$PATH"
 


### PR DESCRIPTION
Claude Code installs its binary to `~/.local/bin/claude` but that directory wasn't in `.paths`, so the `claude` command wasn't found in terminal.

For now, just open a new terminal tab and `claude` should work.