### PR TITLE
Fix Claude CLI PATH + add 1Password to productivity apps

### DIFF
--- a/.dotfiles.dev.yaml
+++ b/.dotfiles.dev.yaml
@@ -60,6 +60,7 @@ homebrew:
     
     # Productivity
     - bitwarden
+    - 1password
     - spotify
     - iina
     - betterzip

--- a/.paths
+++ b/.paths
@@ -11,3 +11,6 @@ export PATH="/opt/homebrew/opt/make/libexec/gnubin:$PATH"
 
 # llvm (Apple Silicon path)
 export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+
+# Local user binaries (Claude Code installer drops `claude` here)
+export PATH="$HOME/.local/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Walk through an interactive wizard:
 | **Cloud** | Docker Desktop, docker-compose |
 | **Apps** | Chrome, VS Code, SourceTree, Proxyman |
 | **Communication** | Slack, Zoom, Telegram, WhatsApp |
-| **Productivity** | Bitwarden, Setapp |
+| **Productivity** | Bitwarden, 1Password, Setapp |
 | **Media** | Spotify, IINA |
 | **AI Tools** | Claude, ChatGPT, Claude Code CLI, Codex CLI |
 | **Mac App Store** | LanScan, Things 3, Magnet |

--- a/Scripts/set_up_dependencies.sh
+++ b/Scripts/set_up_dependencies.sh
@@ -266,8 +266,14 @@ else
     echo "⚠️  Node.js not installed, skipping Claude Code CLI installation"
 fi
 
-
-
+# Verify claude command is reachable in current shell
+if command -v claude >/dev/null 2>&1; then
+    echo "✅ Claude CLI available in PATH ($(command -v claude))"
+else
+    echo "⚠️  Claude CLI installed but not in PATH for this shell."
+    echo "   Add this to your ~/.paths (or ~/.zshrc), then open a new terminal:"
+    echo "   export PATH=\"$HOME/.local/bin:$PATH\""
+fi
 
 echo
 echo "========================================"

--- a/profiles/work.yaml
+++ b/profiles/work.yaml
@@ -9,7 +9,7 @@ android: [android-studio, openjdk, bundletool, env-vars, sdk-license]
 cloud: [docker, docker-compose]
 apps: [google-chrome, visual-studio-code, sublime-text, sourcetree, proxyman]
 comms: [slack, zoom, telegram, whatsapp]
-productivity: [bitwarden, setapp]
+productivity: [bitwarden, 1password, setapp]
 media: [spotify, iina]
 ai: [claude, chatgpt, claude-code, codex]
 macos:

--- a/src/modules/productivity.ts
+++ b/src/modules/productivity.ts
@@ -3,6 +3,7 @@ import { detectCasks, installCask, installCasks } from './helpers';
 
 const items = [
   { id: 'bitwarden', label: 'Bitwarden' },
+  { id: '1password', label: '1Password' },
   { id: 'betterzip', label: 'BetterZip' },
   { id: 'setapp', label: 'Setapp' },
   { id: 'dockdoor', label: 'DockDoor' },

--- a/src/reset.ts
+++ b/src/reset.ts
@@ -64,6 +64,7 @@ const MANAGED_CASKS = [
   'whatsapp',
   // 'telegram', — skipped: control channel for OpenClaw, same install path as other casks
   'bitwarden',
+  '1password',
   'betterzip',
   'setapp',
   'dockdoor',

--- a/src/status.ts
+++ b/src/status.ts
@@ -53,6 +53,7 @@ const MANAGED_CASKS = new Set([
   'whatsapp',
   'telegram',
   'bitwarden',
+  '1password',
   'betterzip',
   'setapp',
   'dockdoor',


### PR DESCRIPTION
## What this fixes

1) **Claude CLI not available in terminal**
- Added `~/.local/bin` to `.paths`.
- Claude native installer places the `claude` binary there, so this makes it reliably available in shell sessions.

2) **Add 1Password alongside Bitwarden**
- Added `1password` to productivity apps in:
  - `profiles/work.yaml`
  - `.dotfiles.dev.yaml`
  - `src/modules/productivity.ts`
  - `src/status.ts` managed casks list
  - `src/reset.ts` managed casks list
- Updated README productivity row.

## Validation
- `npm run build` passes.
