### PR TITLE
Fix Claude CLI setup: use official installer

### DIFF
--- a/Scripts/set_up_dependencies.sh
+++ b/Scripts/set_up_dependencies.sh
@@ -254,16 +254,21 @@ echo "🤖 Installing AI Assistant Tools..."
 echo "========================================"
 echo
 
-# Install Claude Code CLI (requires Node.js)
-if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
-    if npm list -g @anthropic-ai/claude-code >/dev/null 2>&1; then
-        echo "✅ Claude Code CLI already installed"
-    else
-        echo "🤖 Installing Claude Code CLI..."
-        npm install -g @anthropic-ai/claude-code
-    fi
+# Install Claude Code CLI (official installer)
+if command -v claude >/dev/null 2>&1; then
+    echo "✅ Claude Code CLI already installed"
+    echo "🔧 Ensuring shell integration is up to date..."
+    claude install stable || true
 else
-    echo "⚠️  Node.js not installed, skipping Claude Code CLI installation"
+    if command -v curl >/dev/null 2>&1; then
+        echo "🤖 Installing Claude Code CLI (official installer via curl)..."
+        curl -fsSL https://claude.ai/install.sh | bash
+    elif command -v wget >/dev/null 2>&1; then
+        echo "🤖 Installing Claude Code CLI (official installer via wget)..."
+        wget -qO- https://claude.ai/install.sh | bash
+    else
+        echo "⚠️  Neither curl nor wget is installed, skipping Claude Code CLI installation"
+    fi
 fi
 
 # Verify claude command is reachable in current shell


### PR DESCRIPTION
This updates setup to use Anthropic's current official Claude Code installer instead of npm global install.

### Changes
- Replace 
added 2 packages in 1s flow with:
  - Setting up Claude Code...

Checking installation status...
Installing Claude Code native build latest...
Setting up launcher and shell integration...
✔ Claude Code successfully installed!

  Version: 2.1.126

  Location: ~/.local/bin/claude


  Next: Run claude --help to get started

✅ Installation complete! (or wget fallback)
- If  already exists, run 
Checking installation status...
Installing Claude Code native build stable...
Setting up launcher and shell integration...
✔ Claude Code successfully installed!

  Version: 2.1.118

  Location: ~/.local/bin/claude


  Next: Run claude --help to get started to refresh shell integration.
- Keep explicit post-install PATH check and guidance.

### Why
Recent setup failures are consistent with outdated CLI install assumptions. The official installer is now the stable path and handles launcher/shell integration directly.
