### PR TITLE
Fix setup: safe Claude PATH handling + fail fast on broken .zshrc

### DIFF
--- a/Scripts/set_up_dependencies.sh
+++ b/Scripts/set_up_dependencies.sh
@@ -276,8 +276,17 @@ if command -v claude >/dev/null 2>&1; then
     echo "✅ Claude CLI available in PATH ($(command -v claude))"
 else
     echo "⚠️  Claude CLI installed but not in PATH for this shell."
-    echo "   Add this to your ~/.paths (or ~/.zshrc), then open a new terminal:"
-    echo "   export PATH=\"$HOME/.local/bin:$PATH\""
+
+    # Dotfiles-managed safe fix: ensure ~/.paths contains ~/.local/bin once.
+    if [ -f "$HOME/.paths" ] && ! grep -q 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.paths"; then
+        echo '' >> "$HOME/.paths"
+        echo '# Local user binaries (Claude Code installer drops `claude` here)' >> "$HOME/.paths"
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.paths"
+        echo "✅ Added ~/.local/bin to ~/.paths"
+    fi
+
+    echo "   Open a new terminal (or run: source ~/.paths) and retry:"
+    echo "   command -v claude && claude --version"
 fi
 
 echo

--- a/_set_up.sh
+++ b/_set_up.sh
@@ -7,6 +7,13 @@
 source .exports
 source Scripts/set_up_symlinks.sh
 
+# Validate zsh config syntax early (avoid broken terminal sessions)
+if ! zsh -n "$HOME/.zshrc" >/dev/null 2>&1; then
+  echo "❌ ~/.zshrc has syntax errors after symlink/setup."
+  echo "   Run: nl -ba ~/.zshrc | sed -n '110,140p'"
+  exit 1
+fi
+
 # Sync state (compare with previous run and optionally remove orphaned packages)
 Scripts/sync_state.sh sync
 


### PR DESCRIPTION
This fixes the setup behavior around Claude CLI and shell config safety.

## Changes
- **Stop suggesting  edits** for Claude PATH in setup messaging.
- When Claude is installed but not found, setup now applies a **safe, idempotent fix** to  (dotfiles-managed location) instead of touching .
- Add early setup guard in : run  and fail fast with a targeted debug hint if syntax is broken.

## Why
A malformed  can block shell startup and make Claude look broken even when it is installed correctly. Using  keeps PATH changes isolated and predictable.
