### PR TITLE
fix(setup): use native installers for Codex and Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ npx github:JARMourato/dotfiles --reset
 Undoes everything:
 - Restores macOS defaults from backup
 - Uninstalls all brew formulas and casks
-- Uninstalls Mac App Store apps, npm globals
+- Uninstalls Mac App Store apps and AI CLIs
 - Removes dotfile symlinks, oh-my-zsh, powerline, fonts
 - Cleans tool data dirs (~/.pyenv, ~/.rbenv, ~/.claude, ~/.gem)
 - Removes homeserver artifacts

--- a/Scripts/set_up_dependencies.sh
+++ b/Scripts/set_up_dependencies.sh
@@ -290,6 +290,32 @@ else
 fi
 
 echo
+
+# Install Codex CLI (official installer)
+if command -v codex >/dev/null 2>&1; then
+    echo "✅ Codex CLI already installed"
+else
+    if command -v curl >/dev/null 2>&1; then
+        echo "🤖 Installing Codex CLI (official standalone installer via curl)..."
+        curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh
+    elif command -v wget >/dev/null 2>&1; then
+        echo "🤖 Installing Codex CLI (official standalone installer via wget)..."
+        wget -qO- https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh
+    else
+        echo "⚠️  Neither curl nor wget is installed, skipping Codex CLI installation"
+    fi
+fi
+
+# Verify codex command is reachable in current shell
+if command -v codex >/dev/null 2>&1; then
+    echo "✅ Codex CLI available in PATH ($(command -v codex))"
+else
+    echo "⚠️  Codex CLI installed but not in PATH for this shell."
+    echo "   Open a new terminal and retry:"
+    echo "   command -v codex && codex --version"
+fi
+
+echo
 echo "========================================"
 echo "🎉 Dependencies Setup Complete!"
 echo "========================================"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from 'node:fs';
 import {
   cancel,
   confirm,
@@ -24,6 +25,7 @@ import { JsonStateManager } from './state';
 import type { InstallOptions, ModuleV2, ProfileConfig } from './types';
 import { detectMachine } from './utils/detect';
 import { getKeychainPassword, setKeychainPassword } from './utils/keychain';
+import { realHome, runCommand } from './utils/shell';
 
 const program = new Command();
 
@@ -78,6 +80,21 @@ function sanitizeItems(module: ModuleV2, items: string[]): string[] {
 
 function legacyIncludes(profile: ProfileConfig, name: string): boolean {
   return Array.isArray(profile.modules) && profile.modules.includes(name);
+}
+
+async function uninstallCodexNative(): Promise<void> {
+  const home = realHome();
+  await fs.rm(path.join(home, '.local', 'bin', 'codex'), { force: true });
+  await fs.rm(path.join(home, '.codex', 'packages', 'standalone'), { recursive: true, force: true });
+
+  const profileCandidates = ['.zprofile', '.bash_profile', '.zshrc', '.bashrc', '.profile'];
+  for (const profile of profileCandidates) {
+    const profilePath = path.join(home, profile);
+    const contents = await fs.readFile(profilePath, 'utf8').catch(() => '');
+    if (!contents.includes('# >>> Codex installer >>>')) continue;
+    const cleaned = contents.replace(/\n?# >>> Codex installer >>>[\s\S]*?# <<< Codex installer <<</g, '');
+    await fs.writeFile(profilePath, cleaned, 'utf8');
+  }
 }
 
 function selectionsFromProfile(profile: ProfileConfig): Record<string, string[]> {
@@ -438,12 +455,11 @@ async function run(): Promise<void> {
         log.info(`  🗑  ${mod.label}: ${parts.join(' + ')}`);
       } else if (mod.name === 'ai') {
         const casks = mod.items.filter((i) => i === 'claude' || i === 'chatgpt');
-        const natives = mod.items.filter((i) => i === 'claude-code');
-        const npms = mod.items.filter((i) => i === 'codex');
+        const natives = mod.items.filter((i) => i === 'claude-code' || i === 'codex');
         const parts: string[] = [];
         if (casks.length > 0) parts.push(`brew uninstall --cask ${casks.join(', ')}`);
-        if (natives.length > 0) parts.push(`claude uninstall`);
-        if (npms.length > 0) parts.push(`npm uninstall -g ${npms.map((p) => p === 'codex' ? '@openai/codex' : p).join(', ')}`);
+        if (natives.includes('claude-code')) parts.push('claude uninstall');
+        if (natives.includes('codex')) parts.push('remove ~/.local/bin/codex + ~/.codex/packages/standalone');
         log.info(`  🗑  ${mod.label}: ${parts.join(' + ')}`);
       } else {
         log.info(`  🗑  ${mod.label}: ${mod.items.join(', ')}`);
@@ -487,16 +503,14 @@ async function run(): Promise<void> {
         if (formulas.length > 0) await uninstallFormulas(formulas, uninstallOpts);
       } else if (mod.name === 'ai') {
         const casks = mod.items.filter((i) => i === 'claude' || i === 'chatgpt');
-        const natives = mod.items.filter((i) => i === 'claude-code');
-        const npms = mod.items.filter((i) => i === 'codex');
+        const natives = mod.items.filter((i) => i === 'claude-code' || i === 'codex');
         if (casks.length > 0) await uninstallCasks(casks, uninstallOpts);
         for (const item of natives) {
-          const bin = item === 'claude-code' ? 'claude' : item;
-          await runCommand(bin, ['uninstall'], { continueOnError: true });
-        }
-        for (const pkg of npms) {
-          const npmName = pkg === 'codex' ? '@openai/codex' : pkg;
-          await runCommand('npm', ['uninstall', '-g', npmName], { continueOnError: true });
+          if (item === 'claude-code') {
+            await runCommand('claude', ['uninstall'], { continueOnError: true });
+          } else if (item === 'codex') {
+            await uninstallCodexNative();
+          }
         }
       }
     }

--- a/src/modules/ai.ts
+++ b/src/modules/ai.ts
@@ -10,12 +10,11 @@ const items = [
 ];
 
 const CASK_IDS = new Set(['claude', 'chatgpt']);
-const NPM_PACKAGES: Record<string, string> = {
-  'codex': '@openai/codex',
-};
-// claude-code uses its native installer (auto-updates)
+// Claude Code and Codex both have official native installers that keep them
+// closer to upstream release/update behavior than package-manager installs.
 const NATIVE_INSTALLERS: Record<string, { install: string[]; bin: string }> = {
   'claude-code': { install: ['bash', '-c', 'curl -fsSL https://claude.ai/install.sh | bash'], bin: 'claude' },
+  'codex': { install: ['bash', '-c', 'curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh'], bin: 'codex' },
 };
 
 export const aiModule: ModuleV2 = {
@@ -27,7 +26,7 @@ export const aiModule: ModuleV2 = {
   dependencies: ['core'],
   async detect(selectedItems) {
     const casks = selectedItems.filter((item) => CASK_IDS.has(item));
-    const cliItems = selectedItems.filter((item) => item in NPM_PACKAGES || item in NATIVE_INSTALLERS);
+    const cliItems = selectedItems.filter((item) => item in NATIVE_INSTALLERS);
 
     const caskDetect = casks.length > 0
       ? await detectCasks(casks)
@@ -74,17 +73,5 @@ export const aiModule: ModuleV2 = {
       return;
     }
 
-    const pkg = NPM_PACKAGES[item];
-    if (pkg) {
-      const result = await runAsUser('npm', ['install', '-g', pkg], {
-        dryRun: opts.dryRun,
-        continueOnError: true,
-        timeoutMs: 180_000,
-      });
-      if (!result.ok) {
-        const err = (result.stderr || result.stdout).trim().slice(0, 300);
-        throw new Error(`npm install -g ${pkg} failed: ${err || 'timed out after 3 minutes'}`);
-      }
-    }
   },
 };

--- a/src/reset.ts
+++ b/src/reset.ts
@@ -79,9 +79,9 @@ const MANAGED_MAS_APPS = [
   { id: 904280696, name: 'Things 3' },
   { id: 441258766, name: 'Magnet' },
 ];
-const NPM_GLOBALS = ['@openai/codex'];
-const NATIVE_UNINSTALLERS: { id: string; bin: string; args: string[] }[] = [
+const NATIVE_UNINSTALLERS: { id: string; bin: string; args?: string[]; cleanupPaths?: string[] }[] = [
   { id: 'claude-code', bin: 'claude', args: ['uninstall'] },
+  { id: 'codex', bin: 'codex', cleanupPaths: ['.local/bin/codex', '.codex/packages/standalone'] },
 ];
 const DOTFILES = ['.aliases', '.exports', '.paths', '.gemrc', '.ruby-version', '.zshrc'];
 const ANDROID_ENV_MARKER = '# macsetup: android env';
@@ -229,14 +229,14 @@ export async function runReset(rootDir: string, dryRun: boolean): Promise<void> 
   log.info(`2) Uninstall formulas: ${MANAGED_FORMULAS.join(', ')}`);
   log.info(`3) Uninstall casks: ${MANAGED_CASKS.join(', ')}`);
   log.info(`4) Uninstall Mac App Store apps: ${MANAGED_MAS_APPS.map((a) => a.name).join(', ')}`);
-  log.info(`5) Uninstall CLI tools: ${NATIVE_UNINSTALLERS.map((n) => n.id).join(', ')}, ${NPM_GLOBALS.join(', ')}`);
+  log.info(`5) Uninstall CLI tools: ${NATIVE_UNINSTALLERS.map((n) => n.id).join(', ')}`);
   log.info(`6) Remove dotfile symlinks + ~/.dotfiles/ directory: ${DOTFILES.join(', ')}`);
   log.info('7) Remove ~/.oh-my-zsh and ~/.config/powerline-shell');
   log.info('8) Uninstall powerline-shell (pip3)');
   log.info('9) Remove Meslo LG fonts from ~/Library/Fonts');
   log.info('10) Remove ANDROID_HOME lines from ~/.exports');
   log.info('11) Remove homeserver artifacts (Plex symlink, workspace symlink)');
-  log.info('12) Remove tool data dirs (~/.pyenv, ~/.rbenv, ~/.claude, ~/.gem, ~/.claude.json)');
+  log.info('12) Remove tool data dirs (~/.pyenv, ~/.rbenv, ~/.claude, ~/.codex, ~/.gem, ~/.claude.json)');
   log.info('13) Skip SSH keys (safety)');
   log.info('14) Skip git config (safety)');
   log.info('15) Skip machine name (safety)');
@@ -295,24 +295,25 @@ export async function runReset(rootDir: string, dryRun: boolean): Promise<void> 
   progress('Uninstalling Mac App Store apps');
   await uninstallMasApps(false);
 
-  // 5) Uninstall CLI tools (native + npm)
+  // 5) Uninstall CLI tools
   progress('Uninstalling CLI tools');
   for (const native of NATIVE_UNINSTALLERS) {
-    log.info(chalk.dim(`  → ${native.id} (native uninstaller)`));
-    if (await commandExists(native.bin)) {
+    log.info(chalk.dim(`  → ${native.id}`));
+    if (native.args && await commandExists(native.bin)) {
       await runAsUser(native.bin, native.args, { continueOnError: true });
     }
-  }
-  for (const pkg of NPM_GLOBALS) {
-    log.info(chalk.dim(`  → ${pkg}`));
-    // Try as user first (normal case), then with sudo if it fails (e.g. global prefix owned by root)
-    const r1 = await runAsUser('npm', ['uninstall', '-g', pkg], { continueOnError: true });
-    if (!r1.ok) {
-      const isRoot = process.getuid?.() === 0;
-      if (isRoot) {
-        await runCommand('npm', ['uninstall', '-g', pkg], { continueOnError: true });
-      } else {
-        await runCommand('sudo', ['npm', 'uninstall', '-g', pkg], { continueOnError: true });
+    for (const relPath of native.cleanupPaths ?? []) {
+      const target = path.join(realHome(), relPath);
+      await fs.rm(target, { recursive: true, force: true });
+      if (relPath === '.local/bin/codex') {
+        const profileCandidates = ['.zprofile', '.bash_profile', '.zshrc', '.bashrc', '.profile'];
+        for (const profile of profileCandidates) {
+          const profilePath = path.join(realHome(), profile);
+          const contents = await fs.readFile(profilePath, 'utf8').catch(() => '');
+          if (!contents.includes('# >>> Codex installer >>>')) continue;
+          const cleaned = contents.replace(/\n?# >>> Codex installer >>>[\s\S]*?# <<< Codex installer <<</g, '');
+          await fs.writeFile(profilePath, cleaned, 'utf8');
+        }
       }
     }
   }

--- a/src/status.ts
+++ b/src/status.ts
@@ -63,9 +63,9 @@ const MANAGED_CASKS = new Set([
   'claude',
   'chatgpt',
 ]);
-const NPM_GLOBALS: { label: string; packageName: string }[] = [];
 const NATIVE_CLI_TOOLS = [
   { label: 'claude-code', bin: 'claude' },
+  { label: 'codex', bin: 'codex' },
 ];
 const MACOS_BASELINE: Record<string, BaselineCheck[]> = {
   dock: [
@@ -117,11 +117,6 @@ async function readDefault(domain: string, key: string): Promise<string | number
   return parseValue(read.stdout);
 }
 
-async function npmGlobalInstalled(packageName: string): Promise<boolean> {
-  const result = await runCommand('npm', ['ls', '-g', packageName, '--depth=0'], { continueOnError: true });
-  return result.ok;
-}
-
 export async function showStatus(rootDir: string): Promise<void> {
   log.info(chalk.bold(chalk.cyan('Status: Brew')));
   const formulasRes = await runCommand('brew', ['list', '--formula'], { continueOnError: true });
@@ -154,11 +149,6 @@ export async function showStatus(rootDir: string): Promise<void> {
     if (check.ok) line(chalk.green('✅'), tool.label, '(installed)');
     else line('☐', tool.label, '(not installed)');
   }
-  for (const pkg of NPM_GLOBALS) {
-    if (await npmGlobalInstalled(pkg.packageName)) line(chalk.green('✅'), pkg.label, '(installed)');
-    else line('☐', pkg.label, '(not installed)');
-  }
-
   log.info(chalk.bold(chalk.cyan('Status: Dotfile Symlinks')));
   for (const dotfile of DOTFILES) {
     const filePath = path.join(realHome(), dotfile);


### PR DESCRIPTION
## Summary
- switch Codex CLI installation from `npm -g` to OpenAI's official standalone installer
- keep Claude Code on Anthropic's native installer path and align status/reset/uninstall logic with native CLI management
- update the legacy dependency setup script so both CLIs follow the current recommended install methods

## Verification
- `npm run typecheck`
- `npm run build`

## Notes
- OpenAI docs currently recommend `curl -fsSL https://chatgpt.com/codex/install.sh | sh` for Codex CLI
- Anthropic docs currently recommend `curl -fsSL https://claude.ai/install.sh | bash` for Claude Code native install
