### PR TITLE
feat: install Bun in core tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Walk through an interactive wizard:
 
 | Module | Items |
 |--------|-------|
-| **Core Tools** | jq, curl, wget, tree, bat, fd, ripgrep, htop |
+| **Core Tools** | jq, curl, wget, tree, bat, fd, ripgrep, htop, Bun |
 | **Terminal** | oh-my-zsh, powerline-shell, Highway theme, Meslo fonts |
 | **Languages** | Python (pyenv), Ruby (rbenv + bundler) |
 | **iOS Dev** | Xcode (via xcodes), swiftlint, swiftformat, xcbeautify, ASC CLI |

--- a/profiles/work.yaml
+++ b/profiles/work.yaml
@@ -1,7 +1,7 @@
 name: work
 description: "Work machine — iOS, Android, Rails (Docker), web dev, AI tools"
 
-core: [jq, curl, wget, tree, bat, fd, ripgrep, htop, gh]
+core: [jq, curl, wget, tree, bat, fd, ripgrep, htop, bun, gh]
 terminal: [oh-my-zsh, powerline, theme, fonts]
 languages: [python, ruby]
 ios: [xcode, swiftlint, swiftformat, xcbeautify, asc]

--- a/src/modules/core.ts
+++ b/src/modules/core.ts
@@ -10,13 +10,14 @@ const items = [
   { id: 'fd', label: 'fd' },
   { id: 'ripgrep', label: 'ripgrep' },
   { id: 'htop', label: 'htop' },
+  { id: 'bun', label: 'Bun' },
   { id: 'gh', label: 'GitHub CLI' },
 ];
 
 export const coreModule: ModuleV2 = {
   name: 'core',
   label: 'Core Tools',
-  description: 'jq, curl, wget, tree, bat, fd, ripgrep, htop, gh',
+  description: 'jq, curl, wget, tree, bat, fd, ripgrep, htop, bun, gh',
   items,
   defaultItems: items.map((item) => item.id),
   async detect(selectedItems) {

--- a/src/reset.ts
+++ b/src/reset.ts
@@ -28,6 +28,7 @@ const MANAGED_FORMULAS = [
   'fd',
   'ripgrep',
   'htop',
+  'bun',
   'swiftlint',
   'swiftformat',
   'cocoapods',

--- a/src/status.ts
+++ b/src/status.ts
@@ -18,6 +18,7 @@ const MANAGED_FORMULAS = new Set([
   'fd',
   'ripgrep',
   'htop',
+  'bun',
   'swiftlint',
   'swiftformat',
   'cocoapods',


### PR DESCRIPTION
## Summary
- add Bun to the managed core Homebrew toolset
- include Bun in the built-in work profile so fresh setups install it
- teach status/reset docs about Bun so it is tracked consistently

## Testing
- npm run build
- npm run typecheck