### PR TITLE
Resolve JAVA_HOME via java_home instead of Android Studio jre

### DIFF
--- a/.exports
+++ b/.exports
@@ -17,7 +17,7 @@ export DOTFILES_DIR="$HOME/.dotfiles"
 
 export NVM_DIR="$HOME/.nvm"
 
-export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jre/Contents/Home
+export JAVA_HOME="$(/usr/libexec/java_home -v 21 2>/dev/null)"
 
 # pyenv root directory. Consumed by pyenv only.
 export PYENV_ROOT="$HOME/.pyenv"

--- a/dotfiles/.exports
+++ b/dotfiles/.exports
@@ -17,7 +17,7 @@ export DOTFILES_DIR="$HOME/.dotfiles"
 
 export NVM_DIR="$HOME/.nvm"
 
-export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jre/Contents/Home
+export JAVA_HOME="$(/usr/libexec/java_home -v 21 2>/dev/null)"
 
 # pyenv root directory. Consumed by pyenv only.
 export PYENV_ROOT="$HOME/.pyenv"


### PR DESCRIPTION
## What

`.exports` (and its `dotfiles/` copy) hardcoded:

```sh
export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jre/Contents/Home
```

Android Studio moved its bundled runtime from `Contents/jre` to `Contents/jbr`, so that directory no longer exists. Every consumer of `JAVA_HOME` then fails with `ERROR: JAVA_HOME is set to an invalid directory` — including `sdkmanager` and Gradle.

## Why this fix

Resolving through `/usr/libexec/java_home` fixes the class of bug, not the instance: the path cannot rot again when a vendor moves its app bundle. Version 21 is pinned because that is what the Android toolchain expects (`gradle/gradle-daemon-jvm.properties` → `toolchainVersion=21`).

```sh
export JAVA_HOME="$(/usr/libexec/java_home -v 21 2>/dev/null)"
```

## Verification

- `zsh -n .exports` passes
- On a live shell the export resolves to `/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home`
- `./gradlew --version` in `tellus-android` then reports `Launcher JVM: 21.0.11 (Eclipse Adoptium)`
- `sdkmanager` installs licenses, `platform-tools` and `platforms;android-37.0` without error

Both copies are patched, since `.exports` and `dotfiles/.exports` are identical and `_set_up.sh` sources the former.